### PR TITLE
Making the project compatible with speech-to-speech

### DIFF
--- a/moonshine/__init__.py
+++ b/moonshine/__init__.py
@@ -4,4 +4,4 @@ from .version import __version__
 ASSETS_DIR = Path(__file__).parents[0] / "assets"
 
 from .model import load_model, Moonshine
-from .transcribe import transcribe, benchmark
+from .transcribe import transcribe, benchmark, load_tokenizer

--- a/moonshine/transcribe.py
+++ b/moonshine/transcribe.py
@@ -35,10 +35,12 @@ def transcribe(audio, model="moonshine/base"):
     assert_audio_size(audio)
 
     tokens = model.generate(audio)
+    return load_tokenizer().decode_batch(tokens)
+
+def load_tokenizer():
     tokenizer_file = ASSETS_DIR / "tokenizer.json"
     tokenizer = tokenizers.Tokenizer.from_file(str(tokenizer_file))
-    return tokenizer.decode_batch(tokens)
-
+    return tokenizer
 
 def benchmark(audio, model="moonshine/base"):
     import time

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numba
 tokenizers==0.20.0
 einops==0.8.0
-librosa==0.10.2.post1
-torch==2.4.1
+librosa>=0.9.0
+torch>=2.4.0
 keras==3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numba
-tokenizers==0.20.0
+tokenizers>=0.19.0
 einops==0.8.0
 librosa>=0.9.0
 torch>=2.4.0


### PR DESCRIPTION
These are the changes I had to make to this project for it to be compatible with speech-to-speech. There's mainly two things:
1) Relax some requirements -> you don't need that specific librosa version since the only thing you do with it is load audio files. The tokenizers requirements could be necessary but I downgraded to 0.19 and didn't find any issues. That makes this project compatible with MeloTTS. 
2) Provide a method to load the tokenizer -> That enabled me to process numpy arrays without using the transcribe implementation. Alternatively, the transcribe implementation could accept numpy arrays but I went this way since it seemed more flexible.