### PR TITLE
Fix install commands for useful-moonshine-onnx

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Using Moonshine with the ONNX runtime is preferable if you want to run the model
 the package with minimal dependencies to support these use cases. To use it, run the following:
 
 ```shell
-uv pip install useful-moonshine-onnx @ git+https://git@github.com/usefulsensors/moonshine.git#subdirectory=moonshine-onnx
+uv pip install useful-moonshine-onnx@git+https://git@github.com/usefulsensors/moonshine.git#subdirectory=moonshine-onnx
 ```
 
 ### 3. Try it out

--- a/demo/moonshine-onnx/requirements.txt
+++ b/demo/moonshine-onnx/requirements.txt
@@ -1,3 +1,3 @@
 silero_vad
 sounddevice
-useful-moonshine-onnx @ git+https://git@github.com/usefulsensors/moonshine.git#subdirectory=moonshine-onnx
+useful-moonshine-onnx@git+https://git@github.com/usefulsensors/moonshine.git#subdirectory=moonshine-onnx


### PR DESCRIPTION
The previous pip install commands in the instructions and requirements erroneously included some whitespace, which resulted in errors when users attempted to install using the install instructions (see #62). This PR corrects the error by removing the whitespace.