### PR TITLE
remove imports of non-existent objects

### DIFF
--- a/moonshine/__init__.py
+++ b/moonshine/__init__.py
@@ -9,6 +9,4 @@ from .transcribe import (
     benchmark,
     load_tokenizer,
     load_audio,
-    transcribe_with_onnx,
 )
-from .onnx_model import MoonshineOnnxModel


### PR DESCRIPTION
function `transcribe_with_onnx` does not exist anymore, as well as `MoonshineOnnxModel`