### PR TITLE
Switch to ORT files for the models, rather than ONNX, to save space

### DIFF
--- a/moonshine/demo/moonshine-web/downloader.js
+++ b/moonshine/demo/moonshine-web/downloader.js
@@ -10,10 +10,10 @@ var models = [
 ]
 
 var layers = [
-    "preprocess.onnx",
-    "encode.onnx",
-    "uncached_decode.onnx",
-    "cached_decode.onnx"
+    "preprocess.ort",
+    "encode.ort",
+    "uncached_decode.ort",
+    "cached_decode.ort"
 ]
 
 console.log("Downloading Moonshine ONNX models from HuggingFace...")
@@ -24,7 +24,7 @@ models.forEach(model => {
         fs.mkdirSync(dir, { recursive: true });
     }
     layers.forEach(layer => {
-        hub.downloadFile({ repo, path: "onnx/" + model + "/" + layer }).then((file) => {
+        hub.downloadFile({ repo, path: "ort/" + model + "/" + layer }).then((file) => {
             file.arrayBuffer().then((buffer) => {
                 fs.writeFile(dir + "/" + layer, Buffer.from(buffer), () => {
                     console.log("\tDownloaded " + model + "/" + layer + " successfully.") 

--- a/moonshine/demo/moonshine-web/src/moonshine.js
+++ b/moonshine/demo/moonshine-web/src/moonshine.js
@@ -22,19 +22,19 @@ export default class Moonshine {
         const sessionOption = { executionProviders: ['wasm', 'cpu'] };
 
         this.model.preprocess = await ort.InferenceSession.create(
-            "moonshine/" + this.model_name + "/preprocess.onnx", sessionOption)
+            "moonshine/" + this.model_name + "/preprocess.ort", sessionOption)
         console.log("preprocess loaded")
 
         this.model.encode = await ort.InferenceSession.create(
-            "moonshine/" + this.model_name + "/encode.onnx", sessionOption)
+            "moonshine/" + this.model_name + "/encode.ort", sessionOption)
         console.log("encode loaded")
 
         this.model.uncached_decode = await ort.InferenceSession.create(
-            "moonshine/" + this.model_name + "/uncached_decode.onnx", sessionOption)
+            "moonshine/" + this.model_name + "/uncached_decode.ort", sessionOption)
         console.log("uncached_decode loaded")
 
         this.model.cached_decode = await ort.InferenceSession.create(
-            "moonshine/" + this.model_name + "/cached_decode.onnx", sessionOption)
+            "moonshine/" + this.model_name + "/cached_decode.ort", sessionOption)
         console.log("cached_decode loaded")
         console.log(this.model_name + " loaded")
     }


### PR DESCRIPTION
The files have been uploaded to HuggingFace in https://huggingface.co/UsefulSensors/moonshine/discussions/4#673fc506532d0d9e44312e93

These were created from the original ONNX versions using the commands:

```bash
py -m onnxruntime.tools.convert_onnx_models_to_ort .\public\moonshine\tiny\
py -m onnxruntime.tools.convert_onnx_models_to_ort .\public\moonshine\base\
```