### PR TITLE
Fixes __version__ not found error with Python 3.13

### DIFF
--- a/moonshine-onnx/setup.py
+++ b/moonshine-onnx/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 def read_version(fname="src/version.py"):
     my_locals = {}
-    exec(compile(open(fname, encoding="utf-8").read(), fname, "exec"), locals=my_locals)
+    exec(compile(open(fname, encoding="utf-8").read(), fname, "exec"), globals(), my_locals)
     return my_locals["__version__"]
 
 setup(

--- a/moonshine-onnx/setup.py
+++ b/moonshine-onnx/setup.py
@@ -5,9 +5,9 @@ from setuptools import setup
 
 
 def read_version(fname="src/version.py"):
-    exec(compile(open(fname, encoding="utf-8").read(), fname, "exec"))
-    return locals()["__version__"]
-
+    my_locals = {}
+    exec(compile(open(fname, encoding="utf-8").read(), fname, "exec"), locals=my_locals)
+    return my_locals["__version__"]
 
 setup(
     name="useful-moonshine-onnx",

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ from setuptools import find_packages, setup
 
 
 def read_version(fname="moonshine/version.py"):
-    exec(compile(open(fname, encoding="utf-8").read(), fname, "exec"))
-    return locals()["__version__"]
-
+    my_locals = {}
+    exec(compile(open(fname, encoding="utf-8").read(), fname, "exec"), locals=my_locals)
+    return my_locals["__version__"]
 
 setup(
     name="useful-moonshine",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 def read_version(fname="moonshine/version.py"):
     my_locals = {}
-    exec(compile(open(fname, encoding="utf-8").read(), fname, "exec"), locals=my_locals)
+    exec(compile(open(fname, encoding="utf-8").read(), fname, "exec"), globals(), my_locals)
     return my_locals["__version__"]
 
 setup(


### PR DESCRIPTION
Python 3.13 introduced a change where the array returned by `locals()` is no longer updated by an `exec()` call. this change is best documented in https://github.com/python/cpython/issues/118888, "Python 3.13.0b1: exec() does not populate locals()". The error message when running `setup.py` in Python 3.13 is:

```python
KeyError: '__version__'
```

Moonshine uses an exec call in both instances of `setup.py` to read the version number. This is a common idiom, and similar code in Pillow is included as part of the bug report:

```python
def get_version():
    version_file = "src/PIL/_version.py"
    with open(version_file, encoding="utf-8") as f:
        exec(compile(f.read(), version_file, "exec"))
    return locals()["__version__"]
```

The fix suggested by the Python maintainers for this code is:

```python
def get_version():
    version_file = "src/PIL/_version.py"
    d = {}
    with open(version_file, encoding="utf-8") as f:
        exec(compile(f.read(), version_file, "exec"), globals(), d)
    return d["__version__"]
```

I've adapted our `get_version()` to use the same approach, supplying an explicit `locals` dictionary to be modified. This should be a backwards-compatible change.

Tested on Python 3.11.12 and Python 3.13.2.

