### PR TITLE
Add attention mask to onnx run call

### DIFF
--- a/moonshine-onnx/src/model.py
+++ b/moonshine-onnx/src/model.py
@@ -45,9 +45,9 @@ class MoonshineOnnxModel(object):
             model_name = model_name.split("/")[-1]
 
         if models_dir is None:
-            assert (
-                model_name is not None
-            ), "model_name should be specified if models_dir is not"
+            assert model_name is not None, (
+                "model_name should be specified if models_dir is not"
+            )
             encoder, decoder = self._load_weights_from_hf_hub(
                 model_name, model_precision
             )

--- a/moonshine/model.py
+++ b/moonshine/model.py
@@ -665,7 +665,9 @@ class Moonshine(object):
 
         tokens = keras.ops.convert_to_tensor([[1]])
         seq_len = keras.ops.convert_to_tensor([1])
-        logits, *cache = self.decoder.uncached_call([tokens, last_hidden_state, seq_len])
+        logits, *cache = self.decoder.uncached_call(
+            [tokens, last_hidden_state, seq_len]
+        )
         output = tokens
         for _ in range(max_len):
             tokens = keras.ops.argmax(logits, axis=-1)


### PR DESCRIPTION
The newer versions of optimum (>=2.0.0) produce onnx files with extra attention_mask inputs. This change adds that input to the run calls. To keep it compatible with older onnx files, this input is added after checking if the list of inputs actually contains attention_mask.