### PR TITLE
Android: Remove unused `parentContext` parameter from `MicTranscriber` constructor

### DIFF
--- a/android/java/main/java/ai/moonshine/voice/MicTranscriber.java
+++ b/android/java/main/java/ai/moonshine/voice/MicTranscriber.java
@@ -13,16 +13,14 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class MicTranscriber extends Transcriber {
   private boolean isRunning = false;
-  private AppCompatActivity parentContext;
   private boolean isMicCaptureLoopStarted = false;
   private MicCaptureProcessor micCaptureProcessor;
   private CompletableFuture<Void> isLoadedSignal = new CompletableFuture<>();
   private CompletableFuture<Void> hasMicPermissionSignal =
       new CompletableFuture<>();
 
-  public MicTranscriber(AppCompatActivity parentContext) {
+  public MicTranscriber() {
     super();
-    this.parentContext = parentContext;
     // When both isLoadedSignal and hasMicPermissionSignal are complete, run
     // startProcessing()
     CompletableFuture.allOf(isLoadedSignal, hasMicPermissionSignal)


### PR DESCRIPTION
The member `parentContext` of type `AppCompatActivity` is not used in the implementation of `MicTranscriber` class.

I am integrating Moonshine ASR in [SmolChat](https://github.com/shubham0204/SmolChat-Android/pull/122), an app built on top of llama.cpp that enables users to chat with local SLMs (GGUFs).  The app uses Koin as its dependency injection framework. Currently, `MicTranscriber` requires an instance of `AppCompatActivity` in its constructor which is difficult for Koin to inject. Koin operates across the lifecycle of the application and getting the instance of the current activity is not straight-forward. Solving this problem motivated me to check the usages of `parentContext` in `MicTranscriber`.

Also, the codebase is neatly organized for different platforms/languages. Kudos to the developers!

@petewarden @keveman 