### PR TITLE
Enable gh release upload command for MacOS and Linux platforms

### DIFF
--- a/scripts/publish-binary.sh
+++ b/scripts/publish-binary.sh
@@ -68,7 +68,7 @@ if ! gh release view v$VERSION >/dev/null 2>&1; then
 	gh release create v$VERSION --title "v$VERSION" --notes "Release v$VERSION"
 fi
 
-# gh release upload v$VERSION $TAR_NAME --clobber
+gh release upload v$VERSION $TAR_NAME --clobber
 
 cd ${REPO_ROOT_DIR}/examples
 


### PR DESCRIPTION
I noticed that the releases pages only included native library builds for Windows. After looking into the release scripts, I found that `scripts/publish-binary.sh` was creating platform-specific binary tarballs for Linux, macOS, and Pi but had the `gh` release upload command commented out, while the Windows equivalent script `scripts/publish-binary.bat` had the upload enabled.

This change simply uncomments the upload command in the shell script so that these binaries are now published to GitHub releases alongside the Windows binaries. (I'm mostly interested in the Linux builds, but the same change will re-enable MacOS.) Obviously, if there is an additional reason to keep this script commented out, and there is something else that needs to be fixed first, please let me know, and I can look into it as well.
