### PR TITLE
Fix Korean model metadata mismatch

### DIFF
--- a/python/src/moonshine_voice/download.py
+++ b/python/src/moonshine_voice/download.py
@@ -84,7 +84,7 @@ MODEL_INFO = {
         "english_name": "Korean",
         "models": [
             {
-                "model_name": "base-ko",
+                "model_name": "tiny-ko",
                 "model_arch": ModelArch.TINY,
                 "download_url": "https://download.moonshine.ai/model/tiny-ko/quantized/tiny-ko",
             }


### PR DESCRIPTION
This PR fixes an inconsistency in the Korean model entry in `python/src/moonshine_voice/download.py`. The `ko` entry used `model_name="base-ko"` while the architecture and URL clearly point to `tiny-ko`. This updates `model_name` to `tiny-ko` to match.