### PR TITLE
Fix markdown link formatting in iOS and Android sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Listens for user-defined action phrases, like "Turn on the lights", using semant
 
 ### iOS
 
-Download [github.com/moonshine-ai/moonshine/releases/latest/download/ios-examples.tar.gz](https://github.com/moonshine-ai/moonshine/releases/latest/download/ios-examples.tar.gz), extract it, and then open the `Transcriber/Transcriber.xcodeproj` project in Xcode.
+Download [ios-examples.tar.gz](https://github.com/moonshine-ai/moonshine/releases/latest/download/ios-examples.tar.gz), extract it, and then open the `Transcriber/Transcriber.xcodeproj` project in Xcode.
 
 ### Android
 
-Download [github.com/moonshine-ai/moonshine/releases/latest/download/android-examples.tar.gz](https://github.com/moonshine-ai/moonshine/releases/latest/download/android-examples.tar.gz), extract it, and then open the `Transcriber` folder in Android Studio.
+Download [android-examples.tar.gz](https://github.com/moonshine-ai/moonshine/releases/latest/download/android-examples.tar.gz), extract it, and then open the `Transcriber` folder in Android Studio.
 
 ### Linux
 


### PR DESCRIPTION
Fixed markdown link formatting issues where the display text contained the full URL instead of a descriptive link text.

Changed iOS link from displaying 'github.com/moonshine-ai/moonshine/releases/latest/download/ios-examples.tar.gz' to 'ios-examples.tar.gz'
Changed Android link from displaying 'github.com/moonshine-ai/moonshine/releases/latest/download/android-examples.tar.gz' to 'android-examples.tar.gz'