### PR TITLE
Fix build for Swift 6.1. Declare AVFoundation import @preconcurrency

### DIFF
--- a/swift/Sources/MoonshineVoice/MicTranscriber.swift
+++ b/swift/Sources/MoonshineVoice/MicTranscriber.swift
@@ -1,4 +1,4 @@
-import AVFoundation
+@preconcurrency import AVFoundation
 import Foundation
 
 /// MicTranscriber is a class that transcribes audio from a microphone.


### PR DESCRIPTION
Swift 6 compiler was erroring because `AVAudioPCMBuffer` is not `Sendable`. Added `@preconcurrency` declaration to AVFoundation import.

Another fix would be to convert the buffer to `[Float]` but this likely isn't needed immediately.

Tested successful compilation and with MoonshineNoteTaker