### PR TITLE
Enable 16KB page-size compatible Android native builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "ai.moonshine.voice"
     compileSdk = 35
-    ndkVersion = "25.2.9519653"
+    ndkVersion = "28.2.13676358"
 
     defaultConfig {
         minSdk = 35
@@ -18,6 +18,11 @@ android {
         ndk {
             // Only build for ARM64 to match the app module
             abiFilters += listOf("arm64-v8a")
+        }
+        externalNativeBuild {
+            cmake {
+                arguments("-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- bump Android NDK to `28.2.13676358`
- set Android CMake argument `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON`

## Why
Google Play requires 16 KB page-size compatibility for Android 15+ targets. This aligns Android Gradle builds with the recommended modern NDK/toolchain path.

## Notes
- Android-only behavior changes
- no API surface changes
