### PR TITLE
Fix clean-build linker failure caused by SPM library name collision on case-insensitive filesystems

### DIFF
--- a/examples/macos/BasicTranscription/Package.swift
+++ b/examples/macos/BasicTranscription/Package.swift
@@ -7,15 +7,15 @@ let package = Package(
     dependencies: [
         // Uncomment this back in when you want to use the locally-built Swift package.
         // .package(path: "../../../swift")
-        .package(url: "https://github.com/moonshine-ai/moonshine-swift.git", from: "0.0.49")
+        .package(url: "https://github.com/moonshine-ai/moonshine-swift.git", from: "0.0.50")
     ],
     targets: [
         .executableTarget(
             name: "BasicTranscription",
             dependencies: [
                 // Uncomment this back in when you want to use the locally-built Swift package.
-                // .product(name: "Moonshine", package: "swift")
-                .product(name: "Moonshine", package: "moonshine-swift")
+                // .product(name: "MoonshineVoice", package: "swift")
+                .product(name: "MoonshineVoice", package: "moonshine-swift")
             ]
         )
     ]

--- a/examples/macos/MicTranscription/Package.swift
+++ b/examples/macos/MicTranscription/Package.swift
@@ -7,15 +7,15 @@ let package = Package(
     dependencies: [
         // Uncomment this back in when you want to use the locally-built Swift package.
         // .package(path: "../../../swift")
-        .package(url: "https://github.com/moonshine-ai/moonshine-swift.git", from: "0.0.49")
+        .package(url: "https://github.com/moonshine-ai/moonshine-swift.git", from: "0.0.50")
     ],
     targets: [
         .executableTarget(
             name: "MicTranscription",
             dependencies: [
                 // Uncomment this back in when you want to use the locally-built Swift package.
-                // .product(name: "Moonshine", package: "swift")
-                .product(name: "Moonshine", package: "moonshine-swift")
+                // .product(name: "MoonshineVoice", package: "swift")
+                .product(name: "MoonshineVoice", package: "moonshine-swift")
             ]
         )
     ]

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .macOS(.v13),
     ],
     products: [
-        .library(name: "Moonshine", type: .static, targets: ["MoonshineVoice"])
+        .library(name: "MoonshineVoice", type: .static, targets: ["MoonshineVoice"])
     ],
     targets: [
         .binaryTarget(

--- a/swift/Package.swift.remote
+++ b/swift/Package.swift.remote
@@ -8,7 +8,7 @@ let package = Package(
         .macOS(.v13),
     ],
     products: [
-        .library(name: "Moonshine", type: .static, targets: ["MoonshineVoice"])
+        .library(name: "MoonshineVoice", type: .static, targets: ["MoonshineVoice"])
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION
## Problem

`swift build` fails on clean builds of the `examples/macos/` examples with undefined symbols for all `moonshine_*` C functions. The root cause is a filename collision on case-insensitive APFS between two files SPM generates in the same build directory:

1. **Copying `libmoonshine.a`** — extracts the C static library from the xcframework (contains all `moonshine_*` symbols)
2. **Archiving `libMoonshine.a`** — creates the product's static archive from `MoonshineVoice` Swift `.o` files only

On case-insensitive APFS, `libmoonshine.a` and `libMoonshine.a` are the same file. Step 2 overwrites step 1. The linker then finds only Swift objects — no C symbols — and fails with undefined symbols.

This only manifests on clean builds. Incremental builds succeed because the archiving step is skipped as "already up to date", leaving the xcframework copy intact.

## Fix

Rename the library product from `"Moonshine"` to `"MoonshineVoice"` in `swift/Package.swift` and `swift/Package.swift.remote`. This changes the archive output to `libMoonshineVoice.a`, eliminating the collision with `libmoonshine.a`.

Consumer code is unaffected — they already `import MoonshineVoice`. The example `Package.swift` files are updated to reference the renamed product and bumped to require `moonshine-swift` `0.0.50` (the release that will carry this fix).

## Verification

Tested by building the macOS xcframework locally, pointing `MicTranscription` at the local Swift package, and running `swift package clean && swift build`. Build output confirms `libMoonshineVoice.a` is archived separately from `libmoonshine.a` and the link succeeds.