### PR TITLE
fix: macOS x86_64 slice in the Swift xcframework build

### DIFF
--- a/core/third-party/onnxruntime/find-ort-library-path.cmake
+++ b/core/third-party/onnxruntime/find-ort-library-path.cmake
@@ -15,7 +15,14 @@ if (ANDROID)
     set(ONNXRUNTIME_LIB_PATH "${CMAKE_CURRENT_LIST_DIR}/lib/android/${ONNXRUNTIME_ABI_DIR}/libonnxruntime.so"  CACHE INTERNAL "")
 elseif(IOS OR MOONSHINE_BUILD_SWIFT)
     if (MOONSHINE_BUILD_SWIFT)
-        set(ONNXRUNTIME_LIB_PATH "${CMAKE_CURRENT_LIST_DIR}/lib/macos/arm64/libonnxruntime.a" CACHE INTERNAL "")
+        # Pick the arch-appropriate static libonnxruntime.a. build-swift.sh drives
+        # macOS builds per-arch (CMAKE_OSX_ARCHITECTURES set to a single arch) and
+        # lipos the resulting libmoonshine.a archives together at the end.
+        if(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+            set(ONNXRUNTIME_LIB_PATH "${CMAKE_CURRENT_LIST_DIR}/lib/macos/x86_64/libonnxruntime.a" CACHE INTERNAL "")
+        else()
+            set(ONNXRUNTIME_LIB_PATH "${CMAKE_CURRENT_LIST_DIR}/lib/macos/arm64/libonnxruntime.a" CACHE INTERNAL "")
+        endif()
     elseif (CMAKE_OSX_SYSROOT STREQUAL "iphonesimulator")
         set(ONNXRUNTIME_LIB_PATH "${CMAKE_CURRENT_LIST_DIR}/lib/ios/simulator/libonnxruntime.a" CACHE INTERNAL "")
     else()

--- a/core/third-party/onnxruntime/lib/macos/x86_64/libonnxruntime.a
+++ b/core/third-party/onnxruntime/lib/macos/x86_64/libonnxruntime.a
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4d7e7d7f0136a5b9482a24e077e679cea0ceb809a49726e5a7de4e6707859c7
+size 45691256

--- a/scripts/build-swift.sh
+++ b/scripts/build-swift.sh
@@ -30,23 +30,70 @@ cmake -B build-simulator \
 	..
 cmake --build build-simulator --config Release
 
-# Build for macOS
-cmake -B build-macos \
+# Build for macOS per-arch, then lipo. The static merge step in core/CMakeLists.txt
+# pulls in libonnxruntime.a from the vendored third-party tree, which is
+# arch-specific (see find-ort-library-path.cmake). Driving both arches from a
+# single cmake invocation would silently drop one slice; instead we build each
+# arch independently and lipo the merged archives together at the end.
+cmake -B build-macos-arm64 \
 	-G Xcode \
-	-DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+	-DCMAKE_OSX_ARCHITECTURES="arm64" \
 	-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
 	-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO \
 	-DMOONSHINE_BUILD_SWIFT=YES \
 	..
-cmake --build build-macos --config Release
+cmake --build build-macos-arm64 --config Release
+
+cmake -B build-macos-x86_64 \
+	-G Xcode \
+	-DCMAKE_OSX_ARCHITECTURES="x86_64" \
+	-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+	-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO \
+	-DMOONSHINE_BUILD_SWIFT=YES \
+	..
+cmake --build build-macos-x86_64 --config Release
 
 MOONSHINE_FRAMEWORK_PHONE=${CORE_BUILD_DIR}/build-phone/Release-iphoneos/moonshine.framework/
 MOONSHINE_FRAMEWORK_SIMULATOR=${CORE_BUILD_DIR}/build-simulator/Release-iphonesimulator/moonshine.framework/
-MOONSHINE_FRAMEWORK_MACOS=${CORE_BUILD_DIR}/build-macos/Release/moonshine.framework/Versions/A/
+MOONSHINE_FRAMEWORK_MACOS_ARM64=${CORE_BUILD_DIR}/build-macos-arm64/Release/moonshine.framework/Versions/A/
+MOONSHINE_FRAMEWORK_MACOS_X86_64=${CORE_BUILD_DIR}/build-macos-x86_64/Release/moonshine.framework/Versions/A/
+MOONSHINE_FRAMEWORK_MACOS=${MOONSHINE_FRAMEWORK_MACOS_ARM64}
 
 mv ${MOONSHINE_FRAMEWORK_PHONE}/moonshine ${MOONSHINE_FRAMEWORK_PHONE}/libmoonshine.a
 mv ${MOONSHINE_FRAMEWORK_SIMULATOR}/moonshine ${MOONSHINE_FRAMEWORK_SIMULATOR}/libmoonshine.a
-mv ${MOONSHINE_FRAMEWORK_MACOS}/moonshine ${MOONSHINE_FRAMEWORK_MACOS}/libmoonshine.a
+mv ${MOONSHINE_FRAMEWORK_MACOS_ARM64}/moonshine ${MOONSHINE_FRAMEWORK_MACOS_ARM64}/libmoonshine.a
+mv ${MOONSHINE_FRAMEWORK_MACOS_X86_64}/moonshine ${MOONSHINE_FRAMEWORK_MACOS_X86_64}/libmoonshine.a
+
+# Thin each per-arch archive to its own arch first. The libtool -static merge
+# step inside core/CMakeLists.txt pulls in the vendored libonnxruntime.a, which
+# is a fat universal archive; merging it into a per-arch libmoonshine.a causes
+# the output to also become fat, but with only ONNX Runtime symbols in the
+# "foreign" slice (no Moonshine code compiled for that arch). A naive
+# lipo -create over the two per-arch archives would then silently keep the
+# first input's foreign slice and discard the real one, leaving libmoonshine.a
+# with a broken x86_64 slice (Moonshine symbols absent). Thinning first
+# guarantees each input provides exactly one well-formed slice.
+thin_to_arch() {
+	local input=$1
+	local arch=$2
+	local output=$3
+	if lipo -info "$input" | grep -q "^Non-fat file"; then
+		cp "$input" "$output"
+	else
+		lipo "$input" -thin "$arch" -output "$output"
+	fi
+}
+
+thin_to_arch ${MOONSHINE_FRAMEWORK_MACOS_ARM64}/libmoonshine.a arm64 \
+	${MOONSHINE_FRAMEWORK_MACOS_ARM64}/libmoonshine-thin.a
+thin_to_arch ${MOONSHINE_FRAMEWORK_MACOS_X86_64}/libmoonshine.a x86_64 \
+	${MOONSHINE_FRAMEWORK_MACOS_X86_64}/libmoonshine-thin.a
+
+lipo -create \
+	${MOONSHINE_FRAMEWORK_MACOS_ARM64}/libmoonshine-thin.a \
+	${MOONSHINE_FRAMEWORK_MACOS_X86_64}/libmoonshine-thin.a \
+	-output ${MOONSHINE_FRAMEWORK_MACOS}/libmoonshine.a.fat
+mv ${MOONSHINE_FRAMEWORK_MACOS}/libmoonshine.a.fat ${MOONSHINE_FRAMEWORK_MACOS}/libmoonshine.a
 
 xcodebuild -create-xcframework \
 	-library ${MOONSHINE_FRAMEWORK_PHONE}/libmoonshine.a \


### PR DESCRIPTION
The shipped Moonshine.xcframework macos-arm64_x86_64 slice has an empty x86_64 slice (all Moonshine symbols missing), which breaks linking for consumers on Intel Macs even though the README states x86_64 is supported. Three things conspire to produce this:

1. find-ort-library-path.cmake hardcoded the arm64 libonnxruntime.a path when MOONSHINE_BUILD_SWIFT=YES, so the libtool-static merge step inside core/CMakeLists.txt tried to merge an arm64-only ORT archive into a supposedly fat (x86_64;arm64) libmoonshine.a. Select the archive per CMAKE_OSX_ARCHITECTURES instead.

2. build-swift.sh drove both arches through a single cmake invocation with CMAKE_OSX_ARCHITECTURES="x86_64;arm64". Combined with (1), the merge step silently dropped Moonshine symbols from the foreign slice. Run cmake twice (once per arch) and lipo -create the resulting archives at the end.

3. The libonnxruntime.a vendored at lib/macos/arm64/ is actually a fat universal archive containing both slices, which meant the per-arch build outputs were themselves fat but with only ORT symbols in the foreign slice. Thin each per-arch libmoonshine.a to its own arch before the final lipo -create, otherwise lipo silently keeps the first input's slice and the x86_64 slice ends up as just ORT again.

Also add the extracted thin x86_64 slice at
lib/macos/x86_64/libonnxruntime.a so the per-arch find-ort path resolves without requiring consumers to split the fat archive themselves.

Verified: nm -arch x86_64 on the resulting libmoonshine.a now shows all moonshine_* symbols, and a downstream macOS app links and runs on Intel hardware.